### PR TITLE
Fix headnurse dashboard page type error

### DIFF
--- a/app/headnursedashboard/page.tsx
+++ b/app/headnursedashboard/page.tsx
@@ -38,11 +38,7 @@ interface LeaveRequest {
     requestedAt: string;
 }
 
-interface HeadNurseDashboardProps {
-    user: User | null; // เปลี่ยนเป็นค่าว่างได้
-}
-
-export default function HeadNurseDashboard({ user: propUser }: HeadNurseDashboardProps) {
+export default function HeadNurseDashboard() {
     const [activeTab, setActiveTab] = useState<"shifts" | "create" | "requests">("shifts");
     const [shifts, setShifts] = useState<Shift[]>([]);
     const [nurses, setNurses] = useState<Nurse[]>([]);
@@ -56,11 +52,11 @@ export default function HeadNurseDashboard({ user: propUser }: HeadNurseDashboar
     });
     const router = useRouter();
 
-    // สถานะในการจัดการผู้ใช้จาก localStorage หรือ props
-    const [user, setUser] = useState<User | null>(propUser || null);
+    // สถานะในการจัดการผู้ใช้จาก localStorage
+    const [user, setUser] = useState<User | null>(null);
 
     useEffect(() => {
-        if (!propUser && typeof window !== "undefined") {
+        if (typeof window !== "undefined") {
             const storedUser = localStorage.getItem("user");
             if (storedUser) {
                 setUser(JSON.parse(storedUser));
@@ -68,7 +64,7 @@ export default function HeadNurseDashboard({ user: propUser }: HeadNurseDashboar
                 setTimeout(() => router.push("/signin"), 0);
             }
         }
-    }, [propUser, router]);
+    }, [router]);
 
     // ดึง Data
     const fetchData = useCallback(async () => {

--- a/app/nursedashboard/page.tsx
+++ b/app/nursedashboard/page.tsx
@@ -16,11 +16,7 @@ interface Shift {
     description?: string;
 }
 
-interface NurseDashboardProps {
-    user: User | null; // Allow user to be null
-}
-
-export default function NurseDashboard({ user: propUser }: NurseDashboardProps) {
+export default function NurseDashboard() {
     const [shifts, setShifts] = useState<Shift[]>([]);
     const [error, setError] = useState<string | null>(null);
     const [notification, setNotification] = useState<{ message: string; type: "success" | "error" } | null>(null);
@@ -30,10 +26,10 @@ export default function NurseDashboard({ user: propUser }: NurseDashboardProps) 
     const [refresh, setRefresh] = useState(0);
     const router = useRouter();
 
-    // ดึง user จาก localStorage หาก propUser เป็น null
-    const [user, setUser] = useState<User | null>(propUser || null);
+    // ดึง user จาก localStorage
+    const [user, setUser] = useState<User | null>(null);
     useEffect(() => {
-        if (!propUser && typeof window !== "undefined") {
+        if (typeof window !== "undefined") {
             const storedUser = localStorage.getItem("user");
             if (storedUser) {
                 setUser(JSON.parse(storedUser));
@@ -41,7 +37,7 @@ export default function NurseDashboard({ user: propUser }: NurseDashboardProps) 
                 setError("กรุณาล็อกอินก่อนใช้งาน");
             }
         }
-    }, [propUser]);
+    }, []);
 
     const fetchShifts = useCallback(async () => {
         if (!user?.token) {

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -15,11 +15,7 @@ export interface User {
     token: string;
 }
 
-interface LoginProps {
-    onLogin?: (user: User) => void; // เปลี่ยนเป็น optional prop
-}
-
-export default function Signin({ onLogin }: LoginProps = {}) {
+export default function Signin() {
     const router = useRouter();
     const [user, setUser] = useState<User | null>(null);
     const [username, setUsername] = useState("");
@@ -65,10 +61,6 @@ export default function Signin({ onLogin }: LoginProps = {}) {
                 token,
             };
             setUser(normalizedUser);
-            // เรียก onLogin เฉพาะเมื่อมีค่าและเป็นฟังก์ชัน
-            if (onLogin && typeof onLogin === "function") {
-                onLogin(normalizedUser);
-            }
             localStorage.setItem("user", JSON.stringify(normalizedUser));
             // ตัวบทบาทสิทธิเข้าถึง หน้าที่จัดไว้
             const role = normalizedUser.role.toLowerCase();


### PR DESCRIPTION
Refactor Next.js page components to remove direct prop acceptance, resolving compilation errors.

The original implementation treated Next.js App Router page components as standard React components expecting props, which is not valid. Page components in the App Router should be default exports without direct props, relying on `searchParams` or `params` for data, or fetching data internally. This PR updates `headnursedashboard`, `nursedashboard`, and `signin` pages to conform to this pattern.

---
<a href="https://cursor.com/background-agent?bcId=bc-2feb5c1a-b19b-454e-8ddf-02220d59fa14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2feb5c1a-b19b-454e-8ddf-02220d59fa14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

